### PR TITLE
Adds support for native s3 locking by making dynamodb optional

### DIFF
--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,45 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "6.17.0"
+  constraints = ">= 4.0.0"
+  hashes = [
+    "h1:V7rm9KGpo/dNJG2u8XfiB9nZIsfYTbAyUE0C0eA5lTc=",
+    "zh:157063d66cd4b5fc650f20f56127e19c9da5d135f4231f9ca0c19a1c0bf6e29d",
+    "zh:2050dc03304b42204e6c58bbb1a2afd4feeac7db55d7c06be77c6b1e2ab46a0f",
+    "zh:2a7f7751eef636ca064700cc4574b9b54a2596d9e2e86b91c45127410d9724c6",
+    "zh:335fd7bb44bebfc4dd1db1c013947e1dde2518c6f2d846aac13b7314414ce461",
+    "zh:545c248d2eb601a7b45a34313096cae0a5201ccf31e7fd99428357ef800051e0",
+    "zh:57d19883a6367c245e885856a1c5395c4c743c20feff631ea4ec7b5e16826281",
+    "zh:66d4f080b8c268d65e8c4758ed57234e5a19deff6073ffc3753b9a4cc177b54e",
+    "zh:6ad50de35970f15e1ed41d39742290c1be80600b7df3a9fbb4c02f353b9586cf",
+    "zh:7af42fa531e4dcb3ddb09f71ca988e90626abbf56a45981c2a6c01d0b364a51b",
+    "zh:9a6a535a879314a9137ec9d3e858b7c490a962050845cf62620ba2bf4ae916a8",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:ca213e0262c8f686fcd40e3fc84d67b8eea1596de988c13d4a8ecd4522ede669",
+    "zh:cc4132f682e9bf17c0649928ad92af4da07ffe7bccfe615d955225cdcf9e7f09",
+    "zh:dfe6de43496d2e2b6dff131fef6ada1e15f1fbba3d47235c751564d22003d05e",
+    "zh:e37d035fa02693a3d47fe636076cce50b6579b6adc0a36a7cf0456a2331c99ec",
+  ]
+}
+
+provider "registry.terraform.io/hashicorp/random" {
+  version     = "3.5.1"
+  constraints = "3.5.1"
+  hashes = [
+    "h1:IL9mSatmwov+e0+++YX2V6uel+dV6bn+fC/cnGDK3Ck=",
+    "zh:04e3fbd610cb52c1017d282531364b9c53ef72b6bc533acb2a90671957324a64",
+    "zh:119197103301ebaf7efb91df8f0b6e0dd31e6ff943d231af35ee1831c599188d",
+    "zh:4d2b219d09abf3b1bb4df93d399ed156cadd61f44ad3baf5cf2954df2fba0831",
+    "zh:6130bdde527587bbe2dcaa7150363e96dbc5250ea20154176d82bc69df5d4ce3",
+    "zh:6cc326cd4000f724d3086ee05587e7710f032f94fc9af35e96a386a1c6f2214f",
+    "zh:78d5eefdd9e494defcb3c68d282b8f96630502cac21d1ea161f53cfe9bb483b3",
+    "zh:b6d88e1d28cf2dfa24e9fdcc3efc77adcdc1c3c3b5c7ce503a423efbdd6de57b",
+    "zh:ba74c592622ecbcef9dc2a4d81ed321c4e44cddf7da799faa324da9bf52a22b2",
+    "zh:c7c5cde98fe4ef1143bd1b3ec5dc04baf0d4cc3ca2c5c7d40d17c0e9b2076865",
+    "zh:dac4bad52c940cd0dfc27893507c1e92393846b024c5a9db159a93c534a3da03",
+    "zh:de8febe2a2acd9ac454b844a4106ed295ae9520ef54dc8ed2faf29f12716b602",
+    "zh:eab0d0495e7e711cca367f7d4df6e322e6c562fc52151ec931176115b83ed014",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # it-ae-tfmod-aws-state
-This is a terraform module for initializing a terraform state backend in AWS. 
+This is a terraform module for initializing a terraform state backend in AWS. It supports DynamoDB or S3 object locking for state locking and outputs a ready-to-use backend configuration to include in your main terraform code.
 
 ## Example usage
 
@@ -7,51 +7,63 @@ A common pattern for using this is to create a folder within your main project n
 
 ```
 module "state_backend" {
-  source = "github.com/tamu-edu/it-ae-tfmod-aws-state?ref=v0.0.2"
-}
+  source = "github.com/tamu-edu/it-ae-tfmod-aws-state?ref=v0.0.4"
 
-output "account_id" {
-  value = module.state_backend.account_id
-}
-
-output "backend_config" {
-  value = <<BACKENDCONFIG
-  backend "s3" {
-    region         = "${module.state_backend.region}"
-    bucket         = "${module.state_backend.bucket}"
-    key            = "terraform-state/main.tfstate"
-    dynamodb_table = "${module.state_backend.dynamodb_table}"
-  }
-  BACKENDCONFIG
+  bucket_name         = "my-terraform-state-bucket"
 }
 ```
 
-To execute, first you must login to the appropriate account. If on a Mac, it is recommended to use [granted](https://www.granted.dev/). Otherwise, you can use the AWS CLI. In any case, once logged in, run command `terraform init` in the folder where you have referenced the module. Then, run `terraform plan` to see what will be created. If satisfied with the results, run command `terraform apply`. This will create the appropriate S3 bucket and DynamoDB entries for holding state files for the main project. The state file for this will be stored on the file system. Be sure to capture the results of the output and copy it into your main Terraform stack. It is recommended to  alter the name of the key to fit the granularity of separation of concerns that you require.
+To execute, first obtain credentials for an AWS account with permissions to create S3 buckets and [optionally] DynamoDB tables. Then run:
 
-Consider adding the following to your `.gitignore` file
+```
+terraform init
+terraform apply
+```
+
+A common use pattern is to create a `setup` folder in your main project to create the state backend before running the rest of your terraform code. An example structure is as follows:
+
+```
+/setup/main.tf  # Code to create the state backend
+/main.tf        # Your main terraform code
+```
+
+When used this way, you can write the backend configuration in your main terraform code as follows:
+
+```
+resource "local_file" "write_parent_backend_config" {
+  content  = module.state_backend.terraform_backend_config
+  filename = "../tf_backend.tf"
+}
+```
+
+When no inputs are provided, the module will create an S3 bucket with a generated name based on the AWS account ID (`terraform-state-{account_id}`). It will not create a DynamoDB table, assuming S3 object locking will be used for state locking (as recommended by AWS and Hashicorp).
+
+## .gitignore recommendation
+Consider adding the following to your `.gitignore` file, updating paths as necessary:
 
 ```
 # .tfstate files
 *.tfstate
 *.tfstate.*
-!terraform-state/*.tfstate
-!terraform-state/*.tfstate.*
+!/setup/*.tfstate
+!/setup/*.tfstate.*
 ```
 
-This will allow committing the actual .tfstate file but only for the state storage bucket.
+This will allow committing the terraform state files for the setup folder while ignoring state files for the rest of your project.
 
-It creates an S3 bucket and a dynamodb table named `terraform-state-{account_id}` by default, which can be customized with inputs. 
 
 <!-- BEGIN_TF_DOCS -->
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | 6.17.0 |
 
 ## Modules
 
@@ -72,14 +84,16 @@ No modules.
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the S3 bucket to create for storing the Terraform state | `string` | `null` | no |
-| <a name="input_dynamodb_table_name"></a> [dynamodb\_table\_name](#input\_dynamodb\_table\_name) | The name of the DynamoDB table to create for storing the Terraform state lock | `string` | `null` | no |
+| <a name="input_dynamodb_table_name"></a> [dynamodb\_table\_name](#input\_dynamodb\_table\_name) | The name of the DynamoDB table to create for storing the Terraform state lock. If omitted, will autogenerate a name based on the AWS account ID. | `string` | `null` | no |
+| <a name="input_use_dynamodb"></a> [use\_dynamodb](#input\_use\_dynamodb) | Whether to create a DynamoDB table for storing the Terraform state lock. If false, S3 object locking will be used. | `bool` | `false` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | n/a |
-| <a name="output_bucket"></a> [bucket](#output\_bucket) | n/a |
-| <a name="output_dynamodb_table"></a> [dynamodb\_table](#output\_dynamodb\_table) | n/a |
-| <a name="output_region"></a> [region](#output\_region) | n/a |
+| <a name="output_account_id"></a> [account\_id](#output\_account\_id) | AWS account ID where state resources were created |
+| <a name="output_bucket"></a> [bucket](#output\_bucket) | The name of the S3 bucket created for storing the Terraform state |
+| <a name="output_dynamodb_table"></a> [dynamodb\_table](#output\_dynamodb\_table) | The name of the DynamoDB table created for storing the Terraform state lock, or null if not created |
+| <a name="output_region"></a> [region](#output\_region) | AWS region where state resources were created |
+| <a name="output_terraform_backend_config"></a> [terraform\_backend\_config](#output\_terraform\_backend\_config) | A terraform backend configuration template |
 <!-- END_TF_DOCS -->

--- a/inputs.tf
+++ b/inputs.tf
@@ -4,8 +4,14 @@ variable "bucket_name" {
   default     = null
 }
 
+variable "use_dynamodb" {
+  description = "Whether to create a DynamoDB table for storing the Terraform state lock. If false, S3 object locking will be used."
+  type        = bool
+  default     = false
+}
+
 variable "dynamodb_table_name" {
-  description = "The name of the DynamoDB table to create for storing the Terraform state lock"
+  description = "The name of the DynamoDB table to create for storing the Terraform state lock. If omitted, will autogenerate a name based on the AWS account ID."
   type        = string
   default     = null
 }

--- a/main.tf
+++ b/main.tf
@@ -4,7 +4,9 @@ data "aws_region" "current" {}
 locals {
   bucket_name         = var.bucket_name != null ? var.bucket_name : "terraform-state-${data.aws_caller_identity.current.account_id}"
   dynamodb_table_name = var.dynamodb_table_name != null ? var.dynamodb_table_name : "terraform-state-${data.aws_caller_identity.current.account_id}"
+  use_s3_locking      = var.dynamodb_table_name == null
 }
+
 resource "aws_s3_bucket" "state" {
   bucket = local.bucket_name
 }
@@ -17,6 +19,8 @@ resource "aws_s3_bucket_versioning" "state" {
 }
 
 resource "aws_dynamodb_table" "state" {
+  count = var.use_dynamodb ? 1 : 0
+
   name         = local.dynamodb_table_name
   billing_mode = "PAY_PER_REQUEST"
   hash_key     = "LockID"
@@ -39,5 +43,7 @@ output "bucket" {
 }
 
 output "dynamodb_table" {
-  value = aws_dynamodb_table.state.id
+  value = var.use_dynamodb ? aws_dynamodb_table.state[0].name : null
+}
+
 }

--- a/main.tf
+++ b/main.tf
@@ -31,7 +31,7 @@ resource "aws_dynamodb_table" "state" {
 }
 
 output "region" {
-  value = data.aws_region.current.name
+  value = data.aws_region.current.region
 }
 
 output "account_id" {

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 4.0"
+    }
+  }
+}
+
 data "aws_caller_identity" "current" {}
 data "aws_region" "current" {}
 

--- a/main.tf
+++ b/main.tf
@@ -40,22 +40,27 @@ resource "aws_dynamodb_table" "state" {
 }
 
 output "region" {
-  value = data.aws_region.current.region
+  description = "AWS region where state resources were created"
+  value       = data.aws_region.current.region
 }
 
 output "account_id" {
-  value = data.aws_caller_identity.current.account_id
+  description = "AWS account ID where state resources were created"
+  value       = data.aws_caller_identity.current.account_id
 }
 
 output "bucket" {
-  value = aws_s3_bucket.state.id
+  description = "The name of the S3 bucket created for storing the Terraform state"
+  value       = aws_s3_bucket.state.id
 }
 
 output "dynamodb_table" {
-  value = var.use_dynamodb ? aws_dynamodb_table.state[0].name : null
+  description = "The name of the DynamoDB table created for storing the Terraform state lock, or null if not created"
+  value       = var.use_dynamodb ? aws_dynamodb_table.state[0].name : null
 }
 
 output "terraform_backend_config" {
+  description = "A terraform backend configuration template"
   value = templatefile("${path.module}/templates/backend.tftpl", {
     account_id     = data.aws_caller_identity.current.account_id
     use_s3_locking = local.use_s3_locking

--- a/main.tf
+++ b/main.tf
@@ -46,4 +46,12 @@ output "dynamodb_table" {
   value = var.use_dynamodb ? aws_dynamodb_table.state[0].name : null
 }
 
+output "terraform_backend_config" {
+  value = templatefile("${path.module}/templates/backend.tftpl", {
+    account_id     = data.aws_caller_identity.current.account_id
+    use_s3_locking = local.use_s3_locking
+    bucket         = aws_s3_bucket.state.id
+    region         = data.aws_region.current.region
+    dynamodb_table = local.dynamodb_table_name
+  })
 }

--- a/templates/backend.tftpl
+++ b/templates/backend.tftpl
@@ -1,0 +1,16 @@
+terraform {
+  %{ if use_s3_locking }
+    required_version = ">= 1.11"
+  %{ endif }
+  backend "s3" {
+    allowed_account_ids = [ "${account_id}" ]
+    region         = "${region}"
+    bucket         = "${bucket}"
+    key            = "terraform-state/main.tfstate"
+    %{ if !use_s3_locking }
+    dynamodb_table = "${dynamodb_table}"
+    %{ else }
+    use_lockfile = true
+    %{ endif }
+  }
+}

--- a/tests/backend.tftest.hcl
+++ b/tests/backend.tftest.hcl
@@ -1,0 +1,47 @@
+run "setup_tests" {
+    module {
+        source = "./tests/setup"
+    }
+}
+
+run "with_dynamodb" {
+  command = apply
+
+  variables {
+    bucket_name         = "${run.setup_tests.bucket_prefix}-state-test"
+    dynamodb_table_name = "my-terraform-lock-table"
+    use_dynamodb        = true
+  }
+
+  # Check that the bucket name is correct
+  assert {
+    condition     = aws_s3_bucket.state.bucket == "${run.setup_tests.bucket_prefix}-state-test"
+    error_message = "Invalid bucket name"
+  }
+
+  # Check that a DynamoDB table will be created
+  assert {
+    condition     = length(aws_dynamodb_table.state) == 1
+    error_message = "DynamoDB table was not created"
+  }
+}
+
+run "without_dynamodb" {
+  command = apply
+
+  variables {
+    bucket_name         = "${run.setup_tests.bucket_prefix}-state-test"
+  }
+
+  # Check that the bucket name is correct
+  assert {
+    condition     = aws_s3_bucket.state.bucket == "${run.setup_tests.bucket_prefix}-state-test"
+    error_message = "Invalid bucket name"
+  }
+
+  # Check that a DynamoDB table will not be created
+  assert {
+    condition     = length(aws_dynamodb_table.state) == 0
+    error_message = "DynamoDB table was created when it should not have been"
+  }
+}

--- a/tests/setup/main.tf
+++ b/tests/setup/main.tf
@@ -1,0 +1,16 @@
+terraform {
+  required_providers {
+    random = {
+      source  = "hashicorp/random"
+      version = "3.5.1"
+    }
+  }
+}
+
+resource "random_pet" "bucket_prefix" {
+  length = 4
+}
+
+output "bucket_prefix" {
+  value = random_pet.bucket_prefix.id
+}


### PR DESCRIPTION
This pull request introduces significant improvements to the Terraform AWS state backend module, focusing on flexibility, documentation, and maintainability. The main enhancements include support for using either DynamoDB or S3 object locking for state locking, an improved backend configuration output, updated documentation, and new automated tests.

**Major changes include:**

### Feature Enhancements

* Added support for choosing between DynamoDB-based state locking and S3 object locking via the new `use_dynamodb` variable. This allows users to opt out of DynamoDB in favor of S3 object locking, aligning with AWS and HashiCorp recommendations. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR1-R18) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR31-R32) [[3]](diffhunk://#diff-789f251e6364f01fb9e2137e4db484c83871dd3658414b61af35b1e8e67fb148R7-R14)
* Introduced the `terraform_backend_config` output, which provides a ready-to-use backend configuration template for easier integration with main Terraform codebases. [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL30-R70) [[2]](diffhunk://#diff-6c3a282e540ffc92a6b7679b879cf83bb9c9d81cbb9bab08edf9b9ad843f42eeR1-R16)

### Documentation Improvements

* Expanded and clarified the `README.md` to document new features, usage patterns, input variables, and outputs, including detailed examples for both S3 and DynamoDB locking scenarios. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L2-R66) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L75-R98)

### Testing and Maintainability

* Added automated tests to verify both DynamoDB and S3 object locking scenarios, ensuring the correct resources are created based on input variables. [[1]](diffhunk://#diff-1448af972c04b3b91aeae267056f467614f63d17a96619a1cfe6ddc07a920569R1-R47) [[2]](diffhunk://#diff-a0b3c5758aefb14d4a5913b5acefba151eabaea3b2d8bbc727dc099bbcaf4f0eR1-R16)


**State Locking Configuration:**

* Added the `use_dynamodb` variable to allow switching between DynamoDB table locking and S3 object locking for Terraform state. The description for `dynamodb_table_name` was updated for clarity. (`inputs.tf`)
* Updated resource logic so the DynamoDB table is only created if `use_dynamodb` is true, and adjusted output references accordingly. (`main.tf`) [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbR31-R32) [[2]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL42-R65)

**Backend Configuration Template:**

* Added a backend configuration template (`backend.tftpl`) that dynamically sets backend options based on the locking method chosen, including `dynamodb_table` or `use_lockfile`. (`templates/backend.tftpl`)
* Added an output for `terraform_backend_config` to render the backend template with the correct variables. (`main.tf`)

**Automated Testing:**

* Introduced test scenarios to verify both DynamoDB and S3 locking behaviors, including setup of random bucket prefixes for isolation. (`tests/backend.tftest.hcl`, `tests/setup/main.tf`) [[1]](diffhunk://#diff-1448af972c04b3b91aeae267056f467614f63d17a96619a1cfe6ddc07a920569R1-R47) [[2]](diffhunk://#diff-a0b3c5758aefb14d4a5913b5acefba151eabaea3b2d8bbc727dc099bbcaf4f0eR1-R16)