### PR TITLE
Adjusts whitespace on conditional output so that resulting file does not contain surperfluous, blank newlines

### DIFF
--- a/templates/backend.tftpl
+++ b/templates/backend.tftpl
@@ -1,16 +1,12 @@
 terraform {
-  %{ if use_s3_locking }
-    required_version = ">= 1.11"
-  %{ endif }
+%{ if use_s3_locking }    required_version = ">= 1.11"
+%{ endif }
   backend "s3" {
     allowed_account_ids = [ "${account_id}" ]
     region         = "${region}"
     bucket         = "${bucket}"
     key            = "terraform-state/main.tfstate"
-    %{ if !use_s3_locking }
-    dynamodb_table = "${dynamodb_table}"
-    %{ else }
-    use_lockfile = true
-    %{ endif }
-  }
+%{ if !use_s3_locking }    dynamodb_table = "${dynamodb_table}"
+%{ else }    use_lockfile = true
+%{ endif }  }
 }


### PR DESCRIPTION
Before
<img width="542" height="270" alt="image" src="https://github.com/user-attachments/assets/4f3e38df-2521-4441-ac04-2f9b3afb8e30" />


After
<img width="568" height="244" alt="image" src="https://github.com/user-attachments/assets/20f7971e-6dd8-48c9-a67c-83f2ed0654ea" />



Screenshots taken with generated text highlighted to demonstrate collapsed tabs on remaining blank lines as well.

Opinionated PR: Template is harder to read/maintain for module maintainers, but resulting user-facing `tf_backend.tf` is tidier.