### PR TITLE
Allows the statefile object key to be customized

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,8 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the S3 bucket to create for storing the Terraform state | `string` | `null` | no |
 | <a name="input_dynamodb_table_name"></a> [dynamodb\_table\_name](#input\_dynamodb\_table\_name) | The name of the DynamoDB table to create for storing the Terraform state lock. If omitted, will autogenerate a name based on the AWS account ID. | `string` | `null` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The name of the key where the statefile will be stored in the bucket. Appended to key\_path. | `string` | `"main.tfstate"` | no |
+| <a name="input_key_path"></a> [key\_path](#input\_key\_path) | Sets the path where the statefile will be stored in the bucket. The key\_name will be appended to this path. | `string` | `"terraform-state"` | no |
 | <a name="input_use_dynamodb"></a> [use\_dynamodb](#input\_use\_dynamodb) | Whether to create a DynamoDB table for storing the Terraform state lock. If false, S3 object locking will be used. | `bool` | `false` | no |
 
 ## Outputs
@@ -95,5 +97,6 @@ No modules.
 | <a name="output_bucket"></a> [bucket](#output\_bucket) | The name of the S3 bucket created for storing the Terraform state |
 | <a name="output_dynamodb_table"></a> [dynamodb\_table](#output\_dynamodb\_table) | The name of the DynamoDB table created for storing the Terraform state lock, or null if not created |
 | <a name="output_region"></a> [region](#output\_region) | AWS region where state resources were created |
-| <a name="output_terraform_backend_config"></a> [terraform\_backend\_config](#output\_terraform\_backend\_config) | A terraform backend configuration template |
+| <a name="output_terraform_backend_config"></a> [terraform\_backend\_config](#output\_terraform\_backend\_config) | A string containing the complete terraform backend specification |
+| <a name="output_terraform_backend_template"></a> [terraform\_backend\_template](#output\_terraform\_backend\_template) | A string containing a partial terraform backend specification with a placeholder for the key |
 <!-- END_TF_DOCS -->

--- a/inputs.tf
+++ b/inputs.tf
@@ -15,3 +15,9 @@ variable "dynamodb_table_name" {
   type        = string
   default     = null
 }
+
+variable "statefile_key" {
+  description = "Sets the path and name of the key where the statefile will be stored in the bucket"
+  type        = string
+  default     = "terraform-state/main.tfstate"
+}

--- a/inputs.tf
+++ b/inputs.tf
@@ -16,8 +16,14 @@ variable "dynamodb_table_name" {
   default     = null
 }
 
-variable "statefile_key" {
-  description = "Sets the path and name of the key where the statefile will be stored in the bucket"
+variable "key_name" {
+  description = "The name of the key where the statefile will be stored in the bucket. Appended to key_path."
   type        = string
-  default     = "terraform-state/main.tfstate"
+  default     = "main.tfstate"
+}
+
+variable "key_path" {
+  description = "Sets the path where the statefile will be stored in the bucket. The key_name will be appended to this path."
+  type        = string
+  default     = "terraform-state"
 }

--- a/main.tf
+++ b/main.tf
@@ -60,7 +60,7 @@ output "dynamodb_table" {
 }
 
 output "terraform_backend_config" {
-  description = "A terraform backend configuration template"
+  description = "A string containing the complete terraform backend specification"
   value = templatefile("${path.module}/templates/backend.tftpl", {
     account_id     = data.aws_caller_identity.current.account_id
     use_s3_locking = local.use_s3_locking
@@ -72,7 +72,7 @@ output "terraform_backend_config" {
 }
 
 output "terraform_backend_template" {
-  description = "A terraform backend configuration template"
+  description = "A string containing a partial terraform backend specification with a placeholder for the key"
   value = templatefile("${path.module}/templates/backend.tftpl", {
     account_id     = data.aws_caller_identity.current.account_id
     use_s3_locking = local.use_s3_locking

--- a/main.tf
+++ b/main.tf
@@ -70,3 +70,15 @@ output "terraform_backend_config" {
     key            = join("/", [var.key_path, var.key_name])
   })
 }
+
+output "terraform_backend_template" {
+  description = "A terraform backend configuration template"
+  value = templatefile("${path.module}/templates/backend.tftpl", {
+    account_id     = data.aws_caller_identity.current.account_id
+    use_s3_locking = local.use_s3_locking
+    bucket         = aws_s3_bucket.state.id
+    region         = data.aws_region.current.region
+    dynamodb_table = local.dynamodb_table_name
+    key            = "$${key}"
+  })
+}

--- a/main.tf
+++ b/main.tf
@@ -67,5 +67,6 @@ output "terraform_backend_config" {
     bucket         = aws_s3_bucket.state.id
     region         = data.aws_region.current.region
     dynamodb_table = local.dynamodb_table_name
+    key            = join("/", [var.key_path, var.key_name])
   })
 }

--- a/templates/backend.tftpl
+++ b/templates/backend.tftpl
@@ -6,7 +6,7 @@ terraform {
     allowed_account_ids = [ "${account_id}" ]
     region         = "${region}"
     bucket         = "${bucket}"
-    key            = "terraform-state/main.tfstate"
+    key            = "${key}"
     %{ if !use_s3_locking }
     dynamodb_table = "${dynamodb_table}"
     %{ else }


### PR DESCRIPTION
This pull request enhances the configurability and flexibility of the Terraform backend state management by introducing new input variables for customizing the S3 state file location and by adding new output options for backend configuration templates. The main changes provide users with more control over how and where their Terraform state files are stored, and improve the documentation to reflect these options.

**Inputs and Backend Configuration Improvements:**

* Added two new input variables, `key_name` and `key_path`, allowing users to customize the path and filename of the Terraform state file stored in S3. (`inputs.tf`, `README.md`) [[1]](diffhunk://#diff-789f251e6364f01fb9e2137e4db484c83871dd3658414b61af35b1e8e67fb148R18-R29) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R88-R89)
* Updated the backend configuration template to use the new `key` variable, making the S3 key for the state file dynamically configurable. (`templates/backend.tftpl`)

**Outputs and Documentation Enhancements:**

* Modified the `terraform_backend_config` output to provide a string containing the complete backend specification, now reflecting the new key configuration. (`main.tf`, `README.md`) [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL63-R82) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R101)
* Added a new output, `terraform_backend_template`, which gives a backend configuration template with a placeholder for the key, supporting more advanced or templated use cases. (`main.tf`, `README.md`) [[1]](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL63-R82) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R101)
* Updated the `README.md` documentation to describe the new inputs and outputs, ensuring users are informed about the new customization options. (`README.md`) [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R88-R89) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L98-R101)