### PR TITLE
Correct  output for aws_region data source

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,12 @@
 # it-ae-tfmod-aws-state
+
 This is a terraform module for initializing a terraform state backend in AWS. It supports DynamoDB or S3 object locking for state locking and outputs a ready-to-use backend configuration to include in your main terraform code.
 
 ## Example usage
 
 A common pattern for using this is to create a folder within your main project named `terraform-state`. An example `main.tf` to use this is as follows:
 
-```
+```terraform
 module "state_backend" {
   source = "github.com/tamu-edu/it-ae-tfmod-aws-state?ref=v1.0.0"
 
@@ -15,21 +16,21 @@ module "state_backend" {
 
 To execute, first obtain credentials for an AWS account with permissions to create S3 buckets and [optionally] DynamoDB tables. Then run:
 
-```
+```bash
 terraform init
 terraform apply
 ```
 
 A common use pattern is to create a `setup` folder in your main project to create the state backend before running the rest of your terraform code. An example structure is as follows:
 
-```
+```bash
 /setup/main.tf  # Code to create the state backend
 /main.tf        # Your main terraform code
 ```
 
 When used this way, you can write the backend configuration in your main terraform code as follows:
 
-```
+```terraform
 resource "local_file" "write_parent_backend_config" {
   content  = module.state_backend.terraform_backend_config
   filename = "../tf_backend.tf"
@@ -39,9 +40,10 @@ resource "local_file" "write_parent_backend_config" {
 When no inputs are provided, the module will create an S3 bucket with a generated name based on the AWS account ID (`terraform-state-{account_id}`). It will not create a DynamoDB table, assuming S3 object locking will be used for state locking (as recommended by AWS and Hashicorp).
 
 ## .gitignore recommendation
+
 Consider adding the following to your `.gitignore` file, updating paths as necessary:
 
-```
+```gitignore
 # .tfstate files
 *.tfstate
 *.tfstate.*
@@ -51,13 +53,13 @@ Consider adding the following to your `.gitignore` file, updating paths as neces
 
 This will allow committing the terraform state files for the setup folder while ignoring state files for the rest of your project.
 
-
 <!-- BEGIN_TF_DOCS -->
+
 ## Requirements
 
 | Name | Version |
 | ---- | ------- |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0, < 7.0.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6 |
 
 ## Providers
 

--- a/README.md
+++ b/README.md
@@ -56,13 +56,13 @@ This will allow committing the terraform state files for the setup folder while 
 ## Requirements
 
 | Name | Version |
-|------|---------|
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.0 |
+| ---- | ------- |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 6.0.0, < 7.0.0 |
 
 ## Providers
 
 | Name | Version |
-|------|---------|
+| ---- | ------- |
 | <a name="provider_aws"></a> [aws](#provider\_aws) | 6.17.0 |
 
 ## Modules
@@ -72,7 +72,7 @@ No modules.
 ## Resources
 
 | Name | Type |
-|------|------|
+| ---- | ---- |
 | [aws_dynamodb_table.state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dynamodb_table) | resource |
 | [aws_s3_bucket.state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket) | resource |
 | [aws_s3_bucket_versioning.state](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_versioning) | resource |
@@ -82,7 +82,7 @@ No modules.
 ## Inputs
 
 | Name | Description | Type | Default | Required |
-|------|-------------|------|---------|:--------:|
+| ---- | ----------- | ---- | ------- | :------: |
 | <a name="input_bucket_name"></a> [bucket\_name](#input\_bucket\_name) | The name of the S3 bucket to create for storing the Terraform state | `string` | `null` | no |
 | <a name="input_dynamodb_table_name"></a> [dynamodb\_table\_name](#input\_dynamodb\_table\_name) | The name of the DynamoDB table to create for storing the Terraform state lock. If omitted, will autogenerate a name based on the AWS account ID. | `string` | `null` | no |
 | <a name="input_key_name"></a> [key\_name](#input\_key\_name) | The name of the key where the statefile will be stored in the bucket. Appended to key\_path. | `string` | `"main.tfstate"` | no |
@@ -92,7 +92,7 @@ No modules.
 ## Outputs
 
 | Name | Description |
-|------|-------------|
+| ---- | ----------- |
 | <a name="output_account_id"></a> [account\_id](#output\_account\_id) | AWS account ID where state resources were created |
 | <a name="output_bucket"></a> [bucket](#output\_bucket) | The name of the S3 bucket created for storing the Terraform state |
 | <a name="output_dynamodb_table"></a> [dynamodb\_table](#output\_dynamodb\_table) | The name of the DynamoDB table created for storing the Terraform state lock, or null if not created |

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.0.0, < 7.0.0"
+      version = ">= 6"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.0"
+      version = ">= 6.42"
     }
   }
 }
@@ -41,7 +41,7 @@ resource "aws_dynamodb_table" "state" {
 
 output "region" {
   description = "AWS region where state resources were created"
-  value       = data.aws_region.current.name
+  value       = data.aws_region.current.id
 }
 
 output "account_id" {
@@ -65,7 +65,7 @@ output "terraform_backend_config" {
     account_id     = data.aws_caller_identity.current.account_id
     use_s3_locking = local.use_s3_locking
     bucket         = aws_s3_bucket.state.id
-    region         = data.aws_region.current.name
+    region         = data.aws_region.current.id
     dynamodb_table = local.dynamodb_table_name
     key            = join("/", [var.key_path, var.key_name])
   })
@@ -77,7 +77,7 @@ output "terraform_backend_template" {
     account_id     = data.aws_caller_identity.current.account_id
     use_s3_locking = local.use_s3_locking
     bucket         = aws_s3_bucket.state.id
-    region         = data.aws_region.current.name
+    region         = data.aws_region.current.id
     dynamodb_table = local.dynamodb_table_name
     key            = "$${key}"
   })

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6.42"
+      version = ">= 6"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ resource "aws_dynamodb_table" "state" {
 
 output "region" {
   description = "AWS region where state resources were created"
-  value       = data.aws_region.current.region
+  value       = data.aws_region.current.name
 }
 
 output "account_id" {

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 6"
+      version = ">= 6.0.0, < 7.0.0"
     }
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -65,7 +65,7 @@ output "terraform_backend_config" {
     account_id     = data.aws_caller_identity.current.account_id
     use_s3_locking = local.use_s3_locking
     bucket         = aws_s3_bucket.state.id
-    region         = data.aws_region.current.region
+    region         = data.aws_region.current.name
     dynamodb_table = local.dynamodb_table_name
     key            = join("/", [var.key_path, var.key_name])
   })
@@ -77,7 +77,7 @@ output "terraform_backend_template" {
     account_id     = data.aws_caller_identity.current.account_id
     use_s3_locking = local.use_s3_locking
     bucket         = aws_s3_bucket.state.id
-    region         = data.aws_region.current.region
+    region         = data.aws_region.current.name
     dynamodb_table = local.dynamodb_table_name
     key            = "$${key}"
   })


### PR DESCRIPTION
`aws_region` data source does not have export an attribute called `region`

This pull request makes a small change to the `region` output in the Terraform configuration. The output value now uses the `id` attribute instead of `region` from the `data.aws_region.current` data source.

BREAKING CHANGE: The required version of the aws Terraform provider is now >= 6.0.0, < 7.0.0 

([main.tfL44-R44](diffhunk://#diff-dc46acf24afd63ef8c556b77c126ccc6e578bc87e3aa09a931f33d9bf2532fbbL44-R44))